### PR TITLE
Removed pkg-resources line from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ matplotlib==2.2.2
 modernize==0.6.1
 mysql-connector-python==8.0.11
 numpy==1.14.5
-pkg-resources==0.0.0
 protobuf==3.6.0
 PyAudio==0.2.11
 pydub==0.22.1


### PR DESCRIPTION
The line `pkg-resources==0.0.0` will cause pip install to fail. This is inserted by pip freeze in debian systems and is a bug. See: https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command

Quick fix. Let me know if I need to do anything else.